### PR TITLE
Various snippet improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,24 +26,25 @@ To set it as the default syntax for a particular extension:
 
 | Trigger  | Content |
 | -------: | ------- |
-| `cs→`    | `var cx = React.addons.classSet;` |
 | `cdm→`   | `componentDidMount() { ... },` |
 | `cdup→`  | `componentDidUpdate(prevProps, prevState) { ... },` |
+| `cs→`    | `var cx = React.addons.classSet;` |
 | `cwm→`   | `componentWillMount() { ... },` |
 | `cwr→`   | `componentWillReceiveProps(nextProps) { ... },` |
 | `cwun→`  | `componentWillUnmount() { ... },` |
 | `cwu→`   | `componentWillUpdate(nextProps, nextState) { ... },` |
 | `cx→`    | `cx({ ... });` |
-| `fup→`   | `forceUpdate(...);` |
+| `fup→`   | `this.forceUpdate(...);` |
+| `gdn→`   | `this.getDOMNode()` |
 | `gdp→`   | `getDefaultProps() { return {...}; },` |
 | `gis→`   | `getInitialState() { return {...}; },` |
-| `ism→`   | `isMounted()` |
+| `ism→`   | `this.isMounted()` |
+| `props→` | `this.props.` |
 | `pt→`    | `propTypes: { ...: React.PropTypes. },` |
 | `rcc→`   | component skeleton |
 | `ren→`   | `render() { return (...); }` |
-| `sst→`   | `setState({ ... });` |
 | `scu→`   | `shouldComponentUpdate(nextProps, nextState) { ... },` |
-| `props→` | `this.props.` |
+| `sst→`   | `this.setState({ ... });` |
 | `state→` | `this.state.` |
 
 ## About

--- a/snippets/forceUpdate.sublime-snippet
+++ b/snippets/forceUpdate.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
     <content><![CDATA[
-forceUpdate(${1:callback});
+this.forceUpdate(${1:callback});
 ]]></content>
     <tabTrigger>fup</tabTrigger>
     <scope>source.js</scope>
-    <description>React: forceUpdate(...)</description>
+    <description>React: this.forceUpdate(...)</description>
 </snippet>

--- a/snippets/getDOMNode.sublime-snippet
+++ b/snippets/getDOMNode.sublime-snippet
@@ -1,0 +1,8 @@
+<snippet>
+    <content><![CDATA[
+this.getDOMNode()
+]]></content>
+    <tabTrigger>gdn</tabTrigger>
+    <scope>source.js</scope>
+    <description>React: this.getDOMNode()</description>
+</snippet>

--- a/snippets/getDefaultProps.sublime-snippet
+++ b/snippets/getDefaultProps.sublime-snippet
@@ -2,7 +2,7 @@
     <content><![CDATA[
 getDefaultProps() {
 	return {
-		${1}
+		${1}: ${2}
 	};
 },
 ]]></content>

--- a/snippets/isMounted.sublime-snippet
+++ b/snippets/isMounted.sublime-snippet
@@ -1,8 +1,8 @@
 <snippet>
     <content><![CDATA[
-isMounted()
+this.isMounted()
 ]]></content>
     <tabTrigger>ism</tabTrigger>
     <scope>source.js</scope>
-    <description>React: isMounted()</description>
+    <description>React: this.isMounted()</description>
 </snippet>

--- a/snippets/setState.sublime-snippet
+++ b/snippets/setState.sublime-snippet
@@ -1,6 +1,6 @@
 <snippet>
     <content><![CDATA[
-setState({
+this.setState({
 	${1}: ${2}
 });
 ]]></content>


### PR DESCRIPTION
Don't get too attached to `getDOMNode` and `isMounted` - they're going away (see https://github.com/facebook/react/pull/2805). When React 0.13.0 lands I'll update these accordingly - like `this.getDOMNode()` `->` `React.findDOMNode(instance)`