### PR TITLE
Rename syntax to "JavaScript 6to5"

### DIFF
--- a/JavaScript 6to5.YAML-tmLanguage
+++ b/JavaScript 6to5.YAML-tmLanguage
@@ -1,5 +1,5 @@
 # [PackageDev] target_format: plist, ext: tmLanguage
-name: JavaScript JSX
+name: JavaScript 6to5
 scopeName: source.js
 fileTypes: [js, htc, jsx]
 uuid: 30c49d33-6e4d-4985-8a18-34431c2535c6

--- a/JavaScript 6to5.tmLanguage
+++ b/JavaScript 6to5.tmLanguage
@@ -13,7 +13,7 @@
 	<key>keyEquivalent</key>
 	<string>^~J</string>
 	<key>name</key>
-	<string>JavaScript JSX</string>
+	<string>JavaScript 6to5</string>
 	<key>patterns</key>
 	<array>
 		<dict>

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Find it as [**6to5**](https://packagecontrol.io/packages/6to5) through [Package 
 To set it as the default syntax for a particular extension:
   1. Open a file with that extension,
   2. Select `View` from the menu,
-  3. Then `Syntax` `->` `Open all with current extension as...` `->` `JavaScript JSX`.
+  3. Then `Syntax` `->` `Open all with current extension as...` `->` `JavaScript 6to5`.
   4. Repeat this for each extension (e.g.: `.js` and `.jsx`).
 
 #### Setting a Color Scheme


### PR DESCRIPTION
After https://github.com/SublimeLinter/SublimeLinter-jsxhint/pull/18 gets merged, I'll merge this one