### PR TITLE
Highlight member expression properties

### DIFF
--- a/JavaScript 6to5.YAML-tmLanguage
+++ b/JavaScript 6to5.YAML-tmLanguage
@@ -783,10 +783,10 @@ repository:
         '1': {name: variable.other.object.js}
 
     # e.g. obj.property
-    - name: meta.property.object.js
-      match: (?<=\.)\s*[_$a-zA-Z][_$\w]*
+    - name: meta.property.js
+      match: (?<=[\.\]])\s*[_$a-zA-Z][_$\w]*
       captures:
-        '2': {name: variable.other.property.js}
+        '0': {name: entity.name.function.js}
 
     - name: variable.other.readwrite.js
       match: '[_$a-zA-Z][_$\w]*'

--- a/JavaScript 6to5.tmLanguage
+++ b/JavaScript 6to5.tmLanguage
@@ -2206,16 +2206,16 @@
 				<dict>
 					<key>captures</key>
 					<dict>
-						<key>2</key>
+						<key>0</key>
 						<dict>
 							<key>name</key>
-							<string>variable.other.property.js</string>
+							<string>entity.name.function.js</string>
 						</dict>
 					</dict>
 					<key>match</key>
-					<string>(?&lt;=\.)\s*[_$a-zA-Z][_$\w]*</string>
+					<string>(?&lt;=[\.\]])\s*[_$a-zA-Z][_$\w]*</string>
 					<key>name</key>
-					<string>meta.property.object.js</string>
+					<string>meta.property.js</string>
 				</dict>
 				<dict>
 					<key>match</key>


### PR DESCRIPTION
Before 
![screen shot 2015-01-19 at 4 29 22 pm](https://cloud.githubusercontent.com/assets/853712/5796264/ba915dbe-9ff8-11e4-9132-cee99be741b1.png)

After
![screen shot 2015-01-19 at 4 29 39 pm](https://cloud.githubusercontent.com/assets/853712/5796260/b62f9650-9ff8-11e4-95b5-0d07f85ef72a.png)

@zertosh I think this is a change for the better, what do you think? Apologies if this is the wrong way to do things, I'm not totally familiar with TextMate syntax highlighting.
