### PR TITLE
Add react concise component snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ To set it as the default syntax for a particular extension:
 | `props→` | `this.props.` |
 | `pt→`    | `propTypes: { ...: React.PropTypes. },` |
 | `rcc→`   | component skeleton |
+| `rcs→`   | concise component skeleton |
 | `ren→`   | `render() { return (...); }` |
 | `scu→`   | `shouldComponentUpdate(nextProps, nextState) { ... },` |
 | `sst→`   | `this.setState({ ... });` |

--- a/snippets/react_component.sublime-snippet
+++ b/snippets/react_component.sublime-snippet
@@ -4,11 +4,11 @@ import React from 'react';
 
 const ${1} = React.createClass({
 
-  render() {
-    return (
-      ${0:<div />}
-    );
-  }
+	render() {
+		return (
+			${0:<div />}
+		);
+	}
 
 });
 

--- a/snippets/react_component_concise.sublime-snippet
+++ b/snippets/react_component_concise.sublime-snippet
@@ -1,0 +1,20 @@
+<snippet>
+    <content><![CDATA[
+import React from 'react';
+
+export default React.createClass({
+
+	${2:  displayName: '${1:myAwesomeComponent}',}
+
+	render() {
+		return (
+			${0:<div />}
+		);
+	}
+
+});
+]]></content>
+    <tabTrigger>rcs</tabTrigger>
+    <scope>source.js</scope>
+    <description>React: concise component skeleton</description>
+</snippet>


### PR DESCRIPTION
Add `rcs` snippet -> react concise component skeleton which simply exports default React.createClass.