### PR TITLE
Use tabs to indent "react component" skeleton

### DIFF
--- a/snippets/react_component.sublime-snippet
+++ b/snippets/react_component.sublime-snippet
@@ -4,15 +4,16 @@ import React from 'react';
 
 const ${1} = React.createClass({
 
-  render() {
-    return (
-      ${0:<div />}
-    );
-  }
+	render() {
+		return (
+			${0:<div />}
+		);
+	}
 
 });
 
 export default ${1};
+
 ]]></content>
     <tabTrigger>rcc</tabTrigger>
     <scope>source.js</scope>


### PR DESCRIPTION
Use tabs instead of spaces to indent the snippet, so if you use spaces for indentation then Sublime will adjust the indentation-level-spaces-count to your setting.