### PR TITLE
Tag names fixes

### DIFF
--- a/JavaScript 6to5.YAML-tmLanguage
+++ b/JavaScript 6to5.YAML-tmLanguage
@@ -962,7 +962,7 @@ repository:
     match: \S*
 
   jsx-tag-open:
-    begin: (<)([_$a-zA-Z][_$\w:.]*)
+    begin: (<)([_$a-zA-Z][-$\w.]*(?<!\.|-))(?=\s|/?>)
     end: (/?>)
     name: tag.open.js
     beginCaptures:
@@ -976,7 +976,7 @@ repository:
     - include: '#jsx-tag-attributes-illegal'
 
   jsx-tag-close:
-    begin: (</)([_$a-zA-Z][_$\w:.]*)
+    begin: (</)([_$a-zA-Z][-$\w.]*(?<!\.|-))
     end: (>)
     name: tag.close.js
     captures:

--- a/JavaScript 6to5.tmLanguage
+++ b/JavaScript 6to5.tmLanguage
@@ -559,7 +559,7 @@
 		<key>jsx-tag-close</key>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;/)([_$a-zA-Z][_$\w:.]*)</string>
+			<string>(&lt;/)([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))</string>
 			<key>captures</key>
 			<dict>
 				<key>1</key>
@@ -600,7 +600,7 @@
 		<key>jsx-tag-open</key>
 		<dict>
 			<key>begin</key>
-			<string>(&lt;)([_$a-zA-Z][_$\w:.]*)</string>
+			<string>(&lt;)([_$a-zA-Z][-$\w.]*(?&lt;!\.|-))(?=\s|/?&gt;)</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>1</key>

--- a/test/jsx-tag-name.jsx
+++ b/test/jsx-tag-name.jsx
@@ -1,0 +1,29 @@
+var a = b<cat()
+var a = b < cat()
+var a = b <cat[1]
+var a = b < cat[1]
+var a = b <cat?
+var a = b < cat?
+var a = b <cat===
+var a = b < cat===
+var a = b <cat&
+var a = b < cat&&
+var a = b <cat++
+var a = b < cat++
+var a = b <cat--
+var a = b < cat--
+
+var a = b <cat /*comment*/ />
+var a = b <cat />
+var a = b <cat/>
+var a = b <cat-dog />
+var a = b <cat-dog/>
+var a = b <cat_dog />
+var a = b <cat-dog />
+var a = b <cat.dog />
+
+var a = b <cat.dog/*comment*/ />
+//
+var a = b <cat- />
+//
+var a = b <cat. />


### PR DESCRIPTION
See https://github.com/6to5/6to5-sublime/issues/29.

This is still tag-like, nothing I can do about this case:
```
i<table
return data
```

But the rest looks good:

![yvrgw](https://cloud.githubusercontent.com/assets/830952/6196036/4f436396-b3a2-11e4-9af7-127ca8155d2c.png)


