### PR TITLE
jsx-tag-attributes-illegal

### DIFF
--- a/JavaScript 6to5.YAML-tmLanguage
+++ b/JavaScript 6to5.YAML-tmLanguage
@@ -895,15 +895,24 @@ repository:
   jsx-tag-attributes:
     patterns:
       - include: '#jsx-tag-attribute-name'
+      - include: '#jsx-tag-attribute-assignment'
       - include: '#jsx-string-double-quoted'
       - include: '#jsx-string-single-quoted'
       - include: '#jsx-evaluated-code'
 
   jsx-tag-attribute-name:
     name: meta.tag.attribute-name.js
-    match: \b([a-zA-Z\-:]+)
+    match: >-
+      (?x)
+        \s*
+        ([_$a-zA-Z][-$\w]*)
+        (?=\s|=|/?>|/\*|//)
     captures:
       '1': {name: entity.other.attribute-name.js}
+
+  jsx-tag-attribute-assignment:
+    name: keyword.operator.assignment.js
+    match: =(?=\s*(?:'|"|{|/\*|//|\n))
 
   jsx-string-double-quoted:
     begin: '"'
@@ -948,6 +957,10 @@ repository:
     patterns:
     - include: '#core'
 
+  jsx-tag-attributes-illegal:
+    name: invalid.illegal.attribute.js
+    match: \S*
+
   jsx-tag-open:
     begin: (<)([_$a-zA-Z][_$\w:.]*)
     end: (/?>)
@@ -958,8 +971,9 @@ repository:
     endCaptures:
       '1': {name: punctuation.definition.tag.end.js}
     patterns:
-    - include: '#jsx-tag-attributes'
     - include: '#comments'
+    - include: '#jsx-tag-attributes'
+    - include: '#jsx-tag-attributes-illegal'
 
   jsx-tag-close:
     begin: (</)([_$a-zA-Z][_$\w:.]*)
@@ -974,7 +988,7 @@ repository:
 
   jsx-tag-invalid:
     name: invalid.illegal.tag.incomplete.js
-    match: <\\s*>
+    match: <\s*>
 
   jsx:
     name: meta.jsx.js

--- a/JavaScript 6to5.tmLanguage
+++ b/JavaScript 6to5.tmLanguage
@@ -498,6 +498,13 @@
 				</dict>
 			</array>
 		</dict>
+		<key>jsx-tag-attribute-assignment</key>
+		<dict>
+			<key>match</key>
+			<string>=(?=\s*(?:'|"|{|/\*|//|\n))</string>
+			<key>name</key>
+			<string>keyword.operator.assignment.js</string>
+		</dict>
 		<key>jsx-tag-attribute-name</key>
 		<dict>
 			<key>captures</key>
@@ -509,7 +516,10 @@
 				</dict>
 			</dict>
 			<key>match</key>
-			<string>\b([a-zA-Z\-:]+)</string>
+			<string>(?x)
+  \s*
+  ([_$a-zA-Z][-$\w]*)
+  (?=\s|=|/?&gt;|/\*|//)</string>
 			<key>name</key>
 			<string>meta.tag.attribute-name.js</string>
 		</dict>
@@ -520,6 +530,10 @@
 				<dict>
 					<key>include</key>
 					<string>#jsx-tag-attribute-name</string>
+				</dict>
+				<dict>
+					<key>include</key>
+					<string>#jsx-tag-attribute-assignment</string>
 				</dict>
 				<dict>
 					<key>include</key>
@@ -534,6 +548,13 @@
 					<string>#jsx-evaluated-code</string>
 				</dict>
 			</array>
+		</dict>
+		<key>jsx-tag-attributes-illegal</key>
+		<dict>
+			<key>match</key>
+			<string>\S*</string>
+			<key>name</key>
+			<string>invalid.illegal.attribute.js</string>
 		</dict>
 		<key>jsx-tag-close</key>
 		<dict>
@@ -572,7 +593,7 @@
 		<key>jsx-tag-invalid</key>
 		<dict>
 			<key>match</key>
-			<string>&lt;\\s*&gt;</string>
+			<string>&lt;\s*&gt;</string>
 			<key>name</key>
 			<string>invalid.illegal.tag.incomplete.js</string>
 		</dict>
@@ -609,11 +630,15 @@
 			<array>
 				<dict>
 					<key>include</key>
+					<string>#comments</string>
+				</dict>
+				<dict>
+					<key>include</key>
 					<string>#jsx-tag-attributes</string>
 				</dict>
 				<dict>
 					<key>include</key>
-					<string>#comments</string>
+					<string>#jsx-tag-attributes-illegal</string>
 				</dict>
 			</array>
 		</dict>

--- a/test/jsx-attributes.jsx
+++ b/test/jsx-attributes.jsx
@@ -1,0 +1,62 @@
+//
+// GOOD JSX
+//
+<div className key>
+<div /*cats*/ className /*dogs*/ key>
+<div /*cats*/className/*dogs*/ key>
+<div
+  /*cats*/className // dogs
+  // more cats
+  />
+<div className='MyClass' key>
+<div className='MyClass' key={1} >
+<div className='MyClass' key={1} />
+<div className = 'MyClass' key={1} />
+<div class-Name= 'MyClass' key />
+<div className= 'MyClass' key =  '' />
+<div className = 'MyClass'
+  key={1} />
+<div
+  className = 'MyClass'
+  key={1} />
+<div className
+  = 'MyClass' key={1} />
+<div className
+  =
+  'MyClass' key={1} />
+<div className/*cats*/= 'MyClass' key />
+<div className=/*dogs*/'MyClass' key />
+<div className/*cats*/=/*dogs*/'MyClass' key />
+
+//
+// BAD JSX
+//
+<div className='MyClass' key / x>
+<div className? />
+<div className? = 'MyClass' key={1} />
+<div .className= 'MyClass' key={1} />
+<div clas#sName= 'MyClass' key />
+<div class:Name ='MyClass' key />
+<div className 'MyClass' key />
+<div
+  key
+  {1} />
+<div className= 'MyClass' key=cats />
+<div className= 'MyClass' key==cats />
+<div className= 'MyClass' key== cats />
+<div className= 'MyClass' key=
+cats />
+<div className='MyClass' = 'cats' key= >
+<div = key= >
+<div
+  =
+  key= >
+<div
+  key
+  = >
+<div
+  'asdasd'>
+<div < >
+< >
+<div className 'MyClass' key=cats />
+<div className= 'MyClass' key=cats


### PR DESCRIPTION
Important change: The `=` inside of the attributes is now captured as a `keyword.operator.assignment.js`, so it'll get the same coloring from your theme as `=` everywhere else. I can change it to capture as something else, but I have to capture it as something so the illegal attributes work.

Caveat: Unmatched attribute pairs across lines are not marked as invalid. This is a Sublime limitation. I have a "stricter" version that requires that the attribute assignment happen on the same line, but this would mark valid JSX as invalid. I'd rather have false negatives than false positives. Thoughts?

![loriy](https://cloud.githubusercontent.com/assets/830952/6201692/b74a1f5e-b486-11e4-99f3-bd40d4284a2b.png)
